### PR TITLE
Make chaff-process more generic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,14 +5,14 @@ import ChaffDependencies.forTests
 lazy val `chaff-reader` = project.
   settings(forPlugin).
   settings(
-    version := "0.1.0",
+    version := "0.1.1",
     libraryDependencies ++= forTests
   )
 
 lazy val `chaff-process` = project.
   settings(forPlugin).
   settings(
-    version := "0.1.0",
+    version := "0.1.1",
     libraryDependencies ++= forTests
   ).
   dependsOn(`chaff-reader`)

--- a/chaff-process/src/main/scala/x7c1/chaff/process/HasProcessLogger.scala
+++ b/chaff-process/src/main/scala/x7c1/chaff/process/HasProcessLogger.scala
@@ -35,7 +35,7 @@ object HasProcessLogger {
         case Right(right) => implicitly[HasLogMessage[RIGHT]] messageOf right
         case Left(left) => implicitly[HasLogMessage[LEFT]] messageOf left
       }
-      monad.flatMap(r)(_.toReader[X, R[X, ?]])
+      monad.flatMap(r)(_.toReader[X, R])
     }
   }
 

--- a/chaff-process/src/main/scala/x7c1/chaff/process/HasProcessLogger.scala
+++ b/chaff-process/src/main/scala/x7c1/chaff/process/HasProcessLogger.scala
@@ -1,7 +1,10 @@
 package x7c1.chaff.process
 
 import sbt.{Logger, ProcessLogger}
-import x7c1.chaff.reader.Reader
+import x7c1.chaff.core.{Apply, Determined, Monad}
+import x7c1.chaff.reader.{BaseReader, Reader}
+
+import scala.language.{higherKinds, reflectiveCalls}
 
 trait HasProcessLogger {
   def logger: ProcessLogger
@@ -17,16 +20,48 @@ object HasProcessLogger {
     override def logger: ProcessLogger = x
   }
 
-  implicit class RichEitherReader[A <: HasProcessLogger, L: HasLogMessage, R: HasLogMessage](
-    reader: Reader[A, Either[L, R]]) {
+  implicit class RichEitherReader[
+  X <: HasProcessLogger,
+  R[X0, T] <: BaseReader[X0, T],
+  LEFT: HasLogMessage,
+  RIGHT: HasLogMessage](reader: R[X, Either[LEFT, RIGHT]])
+    (implicit
+      monad: Monad[R[X, ?]],
+      apply: Apply[R[X, ?]],
+      determined: Determined[R[X, ?], X]) {
 
-    def asLoggerApplied: Reader[A, Unit] = {
-      reader map {
-        case Right(right) => implicitly[HasLogMessage[R]] messageOf right
-        case Left(left) => implicitly[HasLogMessage[L]] messageOf left
-      } flatMap (_.toReader)
+    def asLoggerApplied: R[X, Unit] = {
+      val r: R[X, LogMessage] = monad.map(reader) {
+        case Right(right) => implicitly[HasLogMessage[RIGHT]] messageOf right
+        case Left(left) => implicitly[HasLogMessage[LEFT]] messageOf left
+      }
+      monad.flatMap(r)(_.toReader[X, R[X, ?]])
     }
   }
+
+  /*
+  type To[A] = Reader[HasProcessLogger, A]
+  def toLogReader: To[Either[L, Int]] = ???
+
+  // compiler cannot infer type [X] here by RichEitherReader0 below
+  toLogReader.asLoggerApplied
+
+  implicit class RichEitherReader0[
+  X <: HasProcessLogger,
+  R[_] <: BaseReader[_, _] : Monad : Apply : Determined[?[_], X],
+  LEFT: HasLogMessage,
+  RIGHT: HasLogMessage](reader: R[Either[LEFT, RIGHT]]) {
+
+    def asLoggerApplied: R[Unit] = {
+      val monad = implicitly[Monad[R]]
+      val r: R[LogMessage] = monad.map(reader) {
+        case Right(right) => implicitly[HasLogMessage[RIGHT]] messageOf right
+        case Left(left) => implicitly[HasLogMessage[LEFT]] messageOf left
+      }
+      monad.flatMap(r)(_.toReader[X, R])
+    }
+  }
+  */
 
   def LogReader[A](f: ProcessLogger => A): Reader[HasProcessLogger, A] =
     Reader { context =>

--- a/chaff-process/src/main/scala/x7c1/chaff/process/LogMessage.scala
+++ b/chaff-process/src/main/scala/x7c1/chaff/process/LogMessage.scala
@@ -4,7 +4,6 @@ import x7c1.chaff.core.{Apply, Determined, Monad, Pure}
 
 import scala.language.{higherKinds, reflectiveCalls}
 
-
 sealed trait LogMessage {
   def messages: Seq[String]
 }
@@ -19,17 +18,21 @@ object LogMessage {
 
     def toReader[
     X <: HasProcessLogger,
-    R[T] : Pure : Apply : Determined[?[_], X]]: R[Unit] = {
+    R[X0, A0]
+    ](implicit
+      pure: Pure[R[X, ?]],
+      apply: Apply[R[X, ?]],
+      determined: Determined[R[X, ?], X]): R[X, Unit] = {
 
-      val rf: R[X => Unit] = implicitly[Pure[R]] pure { context =>
+      val rf: R[X, X => Unit] = pure pure { context =>
         val logger = context.logger
         message match {
           case _: Error => message.messages foreach (logger.error(_))
           case _: Info => message.messages foreach (logger.info(_))
         }
       }
-      val rx: R[X] = implicitly[Determined[R, X]].applied
-      implicitly[Apply[R]].apply(rf)(rx)
+      val rx: R[X, X] = determined.applied
+      apply(rf)(rx)
     }
   }
 
@@ -44,10 +47,10 @@ object LogMessage {
     def uniteSequentially: R[X, Unit] = {
       def loop(xs: Seq[R[X, LogMessage]]): R[X, Unit] = xs match {
         case head +: Nil =>
-          monad.flatMap(head)(_.toReader[X, R[X, ?]])
+          monad.flatMap(head)(_.toReader[X, R])
         case head +: tail => monad.flatMap(head) {
-          case m: Info => monad.flatMap(m.toReader[X, R[X, ?]])(_ => loop(tail))
-          case m: Error => m.toReader[X, R[X, ?]]
+          case m: Info => monad.flatMap(m.toReader[X, R])(_ => loop(tail))
+          case m: Error => m.toReader[X, R]
         }
       }
 

--- a/chaff-process/src/main/scala/x7c1/chaff/process/LogMessage.scala
+++ b/chaff-process/src/main/scala/x7c1/chaff/process/LogMessage.scala
@@ -1,6 +1,8 @@
 package x7c1.chaff.process
 
-import x7c1.chaff.reader.Reader
+import x7c1.chaff.core.{Apply, Determined, Monad, Pure}
+
+import scala.language.{higherKinds, reflectiveCalls}
 
 
 sealed trait LogMessage {
@@ -13,18 +15,43 @@ object LogMessage {
 
   case class Info(messages: String*) extends LogMessage
 
-  case class Multiple(raw: Seq[LogMessage]) extends LogMessage {
-    override def messages: Seq[String] = raw.flatMap(_.messages)
+  implicit class ReaderLike(message: LogMessage) {
+
+    def toReader[
+    X <: HasProcessLogger,
+    R[T] : Pure : Apply : Determined[?[_], X]]: R[Unit] = {
+
+      val rf: R[X => Unit] = implicitly[Pure[R]] pure { context =>
+        val logger = context.logger
+        message match {
+          case _: Error => message.messages foreach (logger.error(_))
+          case _: Info => message.messages foreach (logger.info(_))
+        }
+      }
+      val rx: R[X] = implicitly[Determined[R, X]].applied
+      implicitly[Apply[R]].apply(rf)(rx)
+    }
   }
 
-  implicit class ReaderLike(message: LogMessage) {
-    def toReader[A <: HasProcessLogger]: Reader[A, Unit] = Reader { context =>
-      val logger = context.logger
-      message match {
-        case _: Error => message.messages foreach (logger.error(_))
-        case _: Info => message.messages foreach (logger.info(_))
-        case Multiple(raw) => (raw map (_.toReader[A])).uniteAll run context
+  implicit class LogMessageReaders[
+  X <: HasProcessLogger,
+  R[X0, A0]](readers: Seq[R[X, LogMessage]])
+    (implicit
+      monad: Monad[R[X, ?]],
+      apply: Apply[R[X, ?]],
+      determined: Determined[R[X, ?], X]) {
+
+    def uniteSequentially: R[X, Unit] = {
+      def loop(xs: Seq[R[X, LogMessage]]): R[X, Unit] = xs match {
+        case head +: Nil =>
+          monad.flatMap(head)(_.toReader[X, R[X, ?]])
+        case head +: tail => monad.flatMap(head) {
+          case m: Info => monad.flatMap(m.toReader[X, R[X, ?]])(_ => loop(tail))
+          case m: Error => m.toReader[X, R[X, ?]]
+        }
       }
+
+      loop(readers)
     }
   }
 

--- a/chaff-process/src/main/scala/x7c1/chaff/process/ProcessRunner.scala
+++ b/chaff-process/src/main/scala/x7c1/chaff/process/ProcessRunner.scala
@@ -5,7 +5,9 @@ import x7c1.chaff.process.HasProcessLogger.LogReader
 
 import scala.util.{Failure, Left, Right, Success, Try}
 
+
 case class ProcessRunner(command: Seq[String]) {
+
   import x7c1.chaff.process.ProcessRunner.To
 
   private def builder = Process(command)
@@ -43,6 +45,7 @@ case class ProcessRunner(command: Seq[String]) {
 }
 
 object ProcessRunner {
+
   import x7c1.chaff.reader.Reader
 
   type To[A] = Reader[HasProcessLogger, A]

--- a/chaff-process/src/main/scala/x7c1/chaff/process/ProcessRunner.scala
+++ b/chaff-process/src/main/scala/x7c1/chaff/process/ProcessRunner.scala
@@ -34,7 +34,7 @@ case class ProcessRunner(command: Seq[String]) {
     def lines: To[Either[ProcessError, Seq[String]]] =
       LogReader { logger =>
         Try {
-          builder lines_! logger
+          builder lines logger
         } match {
           case Success(lines) => Right(lines.toIndexedSeq)
           case Failure(exception) => Left(ProcessError(exception))

--- a/chaff-process/src/test/scala/x7c1/chaff/process/LogMessageReadersTest.scala
+++ b/chaff-process/src/test/scala/x7c1/chaff/process/LogMessageReadersTest.scala
@@ -1,0 +1,44 @@
+package x7c1.chaff.process
+
+import org.scalatest.{FreeSpecLike, Matchers}
+import x7c1.chaff.process.LogMessage.{Error, Info}
+import x7c1.chaff.reader.Reader
+
+import scala.util.{Left, Right}
+
+class LogMessageReadersTest extends FreeSpecLike with Matchers {
+
+  "Seq[R[X, LogMessage]]" - {
+    ".uniteSequentially can generate R[X, Unit] that" - {
+
+      val toMessage: Either[ProcessError, Seq[String]] => LogMessage = {
+        case Right(lines) => Info(lines mkString "\n")
+        case Left(error) => Error(error.cause.getMessage)
+      }
+      val target: Seq[ProcessRunner] => Seq[Reader[HasProcessLogger, LogMessage]] = {
+        _ map (_.lines) map (_ map toMessage)
+      }
+      "should run readers until Error found" in {
+        val runners = Seq(
+          ProcessRunner(Seq("ls")),
+          ProcessRunner(Seq("foobar"))
+        )
+        val logger = new BufferedLogger
+        target(runners).uniteSequentially run logger
+
+        logger.lines should contain inOrder("[run] ls", "[run] foobar")
+      }
+      "should stop execution when Error found" in {
+        val runners = Seq(
+          ProcessRunner(Seq("foobar")),
+          ProcessRunner(Seq("ls"))
+        )
+        val logger = new BufferedLogger
+        target(runners).uniteSequentially run logger
+
+        logger.lines should contain("[run] foobar")
+        logger.lines shouldNot contain("[run] ls")
+      }
+    }
+  }
+}

--- a/chaff-process/src/test/scala/x7c1/chaff/process/LogMessageTest.scala
+++ b/chaff-process/src/test/scala/x7c1/chaff/process/LogMessageTest.scala
@@ -1,0 +1,21 @@
+package x7c1.chaff.process
+
+import org.scalatest.{FreeSpecLike, Matchers}
+import x7c1.chaff.process.LogMessage.Info
+import x7c1.chaff.reader.Reader
+
+class LogMessageTest extends FreeSpecLike with Matchers {
+
+  "LogMessage" - {
+    ".toReader" - {
+      "should return R[X, Unit]" in {
+        val reader = Info("foo").toReader[HasProcessLogger, Reader]
+        val logger = new BufferedLogger
+        reader run logger
+        logger.lines shouldBe Seq("foo")
+      }
+    }
+
+  }
+
+}

--- a/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerImplicitsTest.scala
+++ b/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerImplicitsTest.scala
@@ -33,13 +33,13 @@ class ProcessRunnerImplicitsTest extends FreeSpecLike with Matchers {
         } yield {
           ProcessRunner(Seq("echo", s"${r1 + r2}"))
         }
-        "should output Right message " - {
+        "should output Right message " in {
           val logger = new BufferedLogger
           target.asLoggerApplied run logger
           logger.lines should contain("[run] echo 123")
           logger.lines should contain("[done] 0")
         }
-        "should output command to logger" - {
+        "should output command to logger" in {
           val logger = new BufferedLogger
           target.asLoggerApplied run logger
           logger.lines should contain("123")
@@ -52,7 +52,7 @@ class ProcessRunnerImplicitsTest extends FreeSpecLike with Matchers {
         } yield {
           ProcessRunner(Seq("echo", s"${r1 + r2}"))
         }
-        "should output Left message" - {
+        "should output Left message" in {
           val logger = new BufferedLogger
           target.asLoggerApplied run logger
           logger.lines should contain("[failed] error1")

--- a/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerImplicitsTest.scala
+++ b/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerImplicitsTest.scala
@@ -1,0 +1,64 @@
+package x7c1.chaff.process
+
+import org.scalatest.{FreeSpecLike, Matchers}
+import x7c1.chaff.process.LogMessage.{Error, Info}
+
+import scala.util.{Left, Right}
+
+class ProcessRunnerImplicitsTest extends FreeSpecLike with Matchers {
+
+  implicit val fromRight = HasLogMessage {
+    exitCode: Int => Info(s"[done] $exitCode")
+  }
+  implicit val fromLeft = HasLogMessage {
+    error: String => Error(s"[failed] $error")
+  }
+
+  private def setup1(i: Option[Int]) = i match {
+    case Some(x) => Right(x)
+    case None => Left("error1")
+  }
+
+  private def setup2(i: Option[Int]) = i match {
+    case Some(x) => Right(x)
+    case None => Left("error2")
+  }
+
+  "() => Either[L: HasLogMessage, ProcessRunner]" - {
+    ".asLoggerApplied" - {
+      "when [ProcessRunner] is given" - {
+        val target = () => for {
+          r1 <- setup1(Some(100)).right
+          r2 <- setup2(Some(23)).right
+        } yield {
+          ProcessRunner(Seq("echo", s"${r1 + r2}"))
+        }
+        "should output Right message " - {
+          val logger = new BufferedLogger
+          target.asLoggerApplied run logger
+          logger.lines should contain("[run] echo 123")
+          logger.lines should contain("[done] 0")
+        }
+        "should output command to logger" - {
+          val logger = new BufferedLogger
+          target.asLoggerApplied run logger
+          logger.lines should contain("123")
+        }
+      }
+      "when [L: HasLogMessage] is given" - {
+        val target = () => for {
+          r1 <- setup1(None).right
+          r2 <- setup2(Some(23)).right
+        } yield {
+          ProcessRunner(Seq("echo", s"${r1 + r2}"))
+        }
+        "should output Left message" - {
+          val logger = new BufferedLogger
+          target.asLoggerApplied run logger
+          logger.lines should contain("[failed] error1")
+        }
+      }
+    }
+  }
+
+}

--- a/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerTest.scala
+++ b/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerTest.scala
@@ -1,5 +1,7 @@
 package x7c1.chaff.process
 
+import java.io.IOException
+
 import org.scalatest.{FlatSpecLike, Matchers}
 import sbt.ProcessLogger
 
@@ -8,7 +10,7 @@ import scala.util.{Left, Right}
 
 class ProcessRunnerTest extends FlatSpecLike with Matchers {
 
-  "#lines" can "return Seq[String] if succeeded" in {
+  ".lines" can "return Seq[String] if succeeded" in {
     val logger = new BufferedLogger
     val runner = ProcessRunner(Seq("ls"))
 
@@ -22,7 +24,7 @@ class ProcessRunnerTest extends FlatSpecLike with Matchers {
     logger.lines should contain("[run] ls")
   }
 
-  "#lines" should "return ProcessError to non-existent command" in {
+  ".lines" should "return ProcessError to non-existent command" in {
     val logger = new BufferedLogger
     val runner = ProcessRunner(Seq("non-existent-command"))
 
@@ -35,7 +37,7 @@ class ProcessRunnerTest extends FlatSpecLike with Matchers {
     logger.lines should contain("[run] non-existent-command")
   }
 
-  "#lines" should "return ProcessError if not succeeded" in {
+  ".lines" should "return ProcessError if not succeeded" in {
     val logger = new BufferedLogger
     val runner = ProcessRunner(Seq("ls", "foobar"))
 
@@ -48,6 +50,34 @@ class ProcessRunnerTest extends FlatSpecLike with Matchers {
     logger.lines should contain("[run] ls foobar")
   }
 
+  ".exitCode" should "return zero if succeeded" in {
+    val logger = new BufferedLogger
+    val runner = ProcessRunner(Seq("ls"))
+
+    runner.exitCode run logger should be(0)
+
+    logger.lines should contain("[run] ls")
+    logger.lines should contain("LICENSE")
+    logger.lines should contain("README.md")
+  }
+
+  ".exitCode" should "throw IOException to non-existent command" in {
+    val logger = new BufferedLogger
+    val runner = ProcessRunner(Seq("non-existent-command"))
+
+    a[IOException] shouldBe thrownBy {
+      runner.exitCode run logger
+    }
+    logger.lines should contain("[run] non-existent-command")
+  }
+
+  ".exitCode" should "return non-zero if not succeeded" in {
+    val logger = new BufferedLogger
+    val runner = ProcessRunner(Seq("ls", "foobar"))
+
+    runner.exitCode run logger shouldNot be(0)
+    logger.lines should contain("[run] ls foobar")
+  }
 }
 
 class BufferedLogger extends ProcessLogger {

--- a/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerTest.scala
+++ b/chaff-process/src/test/scala/x7c1/chaff/process/ProcessRunnerTest.scala
@@ -1,0 +1,61 @@
+package x7c1.chaff.process
+
+import org.scalatest.{FlatSpecLike, Matchers}
+import sbt.ProcessLogger
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.{Left, Right}
+
+class ProcessRunnerTest extends FlatSpecLike with Matchers {
+
+  "#lines" can "return Seq[String] if succeeded" in {
+    val logger = new BufferedLogger
+    val runner = ProcessRunner(Seq("ls"))
+
+    runner.lines run logger match {
+      case Left(error) =>
+        fail(error.cause)
+      case Right(lines) =>
+        lines should contain("LICENSE")
+        lines should contain("README.md")
+    }
+    logger.lines should contain("[run] ls")
+  }
+
+  "#lines" should "return ProcessError to non-existent command" in {
+    val logger = new BufferedLogger
+    val runner = ProcessRunner(Seq("non-existent-command"))
+
+    runner.lines run logger match {
+      case Left(error) =>
+        error.cause.getMessage should include("error=2")
+      case Right(lines) =>
+        fail(s"unexpected output: $lines")
+    }
+    logger.lines should contain("[run] non-existent-command")
+  }
+
+  "#lines" should "return ProcessError if not succeeded" in {
+    val logger = new BufferedLogger
+    val runner = ProcessRunner(Seq("ls", "foobar"))
+
+    runner.lines run logger match {
+      case Left(error) =>
+        error.cause.getMessage should include("Nonzero exit code: 1")
+      case Right(lines) =>
+        fail(s"unexpected output: $lines")
+    }
+    logger.lines should contain("[run] ls foobar")
+  }
+
+}
+
+class BufferedLogger extends ProcessLogger {
+  val lines: ArrayBuffer[String] = new ArrayBuffer()
+
+  override def info(s: => String): Unit = lines += s
+
+  override def error(s: => String): Unit = lines += s
+
+  override def buffer[T](f: => T): T = f
+}

--- a/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
@@ -11,9 +11,9 @@ trait Monad[F[_]] extends Pure[F] with FlatMap[F] with Functor[F] {
 
 object Monad {
 
-  class ForUnits[B[_] : Monad](readers: Seq[B[Unit]]) {
-    def uniteAll: B[Unit] = {
-      val nop = implicitly[Monad[B]] pure {}
+  class ForUnits[F[_] : Monad](readers: Seq[F[Unit]]) {
+    def uniteAll: F[Unit] = {
+      val nop = implicitly[Monad[F]] pure {}
       readers.foldLeft(nop) {
         (a, b) => FlatMap.append(a, b)
       }

--- a/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
@@ -2,7 +2,12 @@ package x7c1.chaff.core
 
 import scala.language.higherKinds
 
-trait Monad[F[_]] extends Pure[F] with FlatMap[F]
+trait Monad[F[_]] extends Pure[F] with FlatMap[F] with Functor[F] {
+
+  override def map[A, B](fa: F[A])(f: A => B): F[B] = {
+    flatMap(fa)(a => pure(f(a)))
+  }
+}
 
 object Monad {
 
@@ -17,6 +22,18 @@ object Monad {
 
 }
 
+trait Functor[F[_]] {
+  def map[A, B](fa: F[A])(f: A => B): F[B]
+}
+
 trait Pure[F[_]] {
-  def pure[A](a: A): F[A]
+  def pure[A](a: => A): F[A]
+}
+
+trait Apply[F[_]] {
+  def apply[A, B](f: F[A => B])(a: F[A]): F[B]
+}
+
+trait Determined[F[_], A] {
+  def applied: F[A]
 }

--- a/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
@@ -19,24 +19,13 @@ object Monad {
     }
   }
 
-  trait FunctorImpl[F[_]] {
-    self: Functor[F] with Pure[F] with FlatMap[F] =>
-
-    override def map[A, B](fa: F[A])(f: A => B): F[B] = {
-      flatMap(fa) { a =>
-        pure(f(a))
-      }
+  class Factory[F[_]] {
+    def from[G[?[_]] : MonadInducible](x: G[F]): Monad[F] = {
+      implicitly[MonadInducible[G]] induceFrom x
     }
   }
 
-  trait ApplyImpl[F[_]] {
-    this: Apply[F] with Functor[F] with FlatMap[F] =>
-
-    override def apply[A, B](fab: F[A => B])(fa: F[A]): F[B] = {
-      flatMap(fab)(map(fa))
-    }
-  }
-
+  def create[F[_]]: Factory[F] = new Factory
 }
 
 trait Functor[F[_]] {

--- a/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/core/Monad.scala
@@ -2,12 +2,11 @@ package x7c1.chaff.core
 
 import scala.language.higherKinds
 
-trait Monad[F[_]] extends Pure[F] with FlatMap[F] with Functor[F] {
-
-  override def map[A, B](fa: F[A])(f: A => B): F[B] = {
-    flatMap(fa)(a => pure(f(a)))
-  }
-}
+trait Monad[F[_]]
+  extends Pure[F]
+    with Functor[F]
+    with FlatMap[F]
+    with Apply[F]
 
 object Monad {
 
@@ -17,6 +16,24 @@ object Monad {
       readers.foldLeft(nop) {
         (a, b) => FlatMap.append(a, b)
       }
+    }
+  }
+
+  trait FunctorImpl[F[_]] {
+    self: Functor[F] with Pure[F] with FlatMap[F] =>
+
+    override def map[A, B](fa: F[A])(f: A => B): F[B] = {
+      flatMap(fa) { a =>
+        pure(f(a))
+      }
+    }
+  }
+
+  trait ApplyImpl[F[_]] {
+    this: Apply[F] with Functor[F] with FlatMap[F] =>
+
+    override def apply[A, B](fab: F[A => B])(fa: F[A]): F[B] = {
+      flatMap(fab)(map(fa))
     }
   }
 

--- a/chaff-reader/src/main/scala/x7c1/chaff/core/MonadInducible.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/core/MonadInducible.scala
@@ -1,0 +1,42 @@
+package x7c1.chaff.core
+
+import scala.language.{higherKinds, implicitConversions}
+
+trait MonadInducible[G[?[_]]] {
+  def induceFrom[F[_]](x: G[F]): Monad[F]
+}
+
+object MonadInducible {
+
+  type PureFlatMap[X[_]] = Pure[X] with FlatMap[X]
+
+  implicit object pureFlatMap extends MonadInducible[PureFlatMap] {
+    override def induceFrom[F[_]](x: PureFlatMap[F]) =
+
+      new Monad[F] with FunctorImpl[F] with ApplyImpl[F] {
+
+        override def pure[A](a: => A) = x.pure(a)
+
+        override def flatMap[A, B](fa: F[A])(f: A => F[B]) = x.flatMap(fa)(f)
+      }
+  }
+
+}
+
+trait FunctorImpl[F[_]] {
+  self: Functor[F] with Pure[F] with FlatMap[F] =>
+
+  override def map[A, B](fa: F[A])(f: A => B): F[B] = {
+    flatMap(fa) { a =>
+      pure(f(a))
+    }
+  }
+}
+
+trait ApplyImpl[F[_]] {
+  this: Apply[F] with Functor[F] with FlatMap[F] =>
+
+  override def apply[A, B](fab: F[A => B])(fa: F[A]): F[B] = {
+    flatMap(fab)(map(fa))
+  }
+}

--- a/chaff-reader/src/main/scala/x7c1/chaff/reader/BaseReader.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/reader/BaseReader.scala
@@ -1,6 +1,6 @@
 package x7c1.chaff.reader
 
-import x7c1.chaff.core.{FlatMap, Monad}
+import x7c1.chaff.core.{Apply, FlatMap, Determined, Monad}
 
 import scala.language.{higherKinds, reflectiveCalls}
 
@@ -29,23 +29,38 @@ trait BaseProvider[R[X, A] <: BaseReader[X, A]] {
 
   def flatMap[X, A, B](fa: R[X, A])(f: A => R[X, B]): R[X, B]
 
+  def empty[X]: R[X, Unit] = apply(_ => {})
+
   implicit class RichUnitReader[A](reader: R[A, Unit])
-    extends FlatMap.ForUnit[({type L[T] = R[A, T]})#L](reader)
+    extends FlatMap.ForUnit[R[A, ?]](reader)
 
   implicit class RichUnitReaders[A](readers: Seq[R[A, Unit]])
-    extends Monad.ForUnits[({type L[T] = R[A, T]})#L](readers)
+    extends Monad.ForUnits[R[A, ?]](readers)
 
-  implicit def monad[X]: Monad[({type L[T] = R[X, T]})#L] = new MonadImpl
-
-  private class MonadImpl[X] extends Monad[({type L[T] = R[X, T]})#L] {
-
-    override def pure[A](a: A) = {
-      BaseProvider.this.apply(_ => a)
+  implicit def readerDetermined[A]: Determined[R[A, ?], A] =
+    new Determined[R[A, ?], A] {
+      override def applied = BaseProvider.this.apply[A, A](identity)
     }
 
-    override def flatMap[A, B](fa: R[X, A])(f: A => R[X, B]) = {
-      BaseProvider.this.flatMap(fa)(f)
+  implicit def readerApply[X]: Apply[R[X, ?]] =
+    new Apply[R[X, ?]] {
+      override def apply[A, B](rf: R[X, A => B])(ra: R[X, A]): R[X, B] =
+        BaseProvider.this.flatMap(rf) { f =>
+          BaseProvider.this.flatMap(ra) { a =>
+            monad pure f(a)
+          }
+        }
     }
-  }
+
+  implicit def monad[X]: Monad[R[X, ?]] =
+    new Monad[R[X, ?]] {
+      override def pure[A](a: => A) = {
+        BaseProvider.this.apply(_ => a)
+      }
+
+      override def flatMap[A, B](fa: R[X, A])(f: A => R[X, B]) = {
+        BaseProvider.this.flatMap(fa)(f)
+      }
+    }
 
 }

--- a/chaff-reader/src/main/scala/x7c1/chaff/reader/BaseReader.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/reader/BaseReader.scala
@@ -1,24 +1,24 @@
 package x7c1.chaff.reader
 
-import x7c1.chaff.core.Monad.{ApplyImpl, FunctorImpl}
-import x7c1.chaff.core.{Determined, FlatMap, Monad}
+import x7c1.chaff.core.MonadInducible.PureFlatMap
+import x7c1.chaff.core.{Determined, FlatMap, Monad, Pure}
 
 import scala.language.{higherKinds, reflectiveCalls}
 
 
 trait BaseReader[X, A] {
 
-  type Type[T] <: BaseReader[X, T]
+  type This[T] <: BaseReader[X, T]
 
   def run: X => A
 
-  def underlying: Type[A]
+  def underlying: This[A]
 
-  def map[B](f: A => B)(implicit m: Monad[Type]): Type[B] = {
+  def map[B](f: A => B)(implicit m: Monad[This]): This[B] = {
     m.flatMap(underlying)(a => m pure f(a))
   }
 
-  def flatMap[B](f: A => Type[B])(implicit m: Monad[Type]): Type[B] = {
+  def flatMap[B](f: A => This[B])(implicit m: Monad[This]): This[B] = {
     m.flatMap(underlying)(f)
   }
 

--- a/chaff-reader/src/main/scala/x7c1/chaff/reader/BaseReader.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/reader/BaseReader.scala
@@ -43,11 +43,8 @@ trait BaseProvider[R[X, A] <: BaseReader[X, A]] {
       override def applied = BaseProvider.this.apply[A, A](identity)
     }
 
-  implicit def monad[X]: Monad[R[X, ?]] =
-    new Monad[R[X, ?]]
-      with FunctorImpl[R[X, ?]]
-      with ApplyImpl[R[X, ?]] {
-
+  implicit def monad[X]: Monad[R[X, ?]] = Monad.create[R[X, ?]].from[PureFlatMap](
+    new Pure[R[X, ?]] with FlatMap[R[X, ?]] {
       override def pure[A](a: => A) = {
         BaseProvider.this.apply(_ => a)
       }
@@ -55,6 +52,7 @@ trait BaseProvider[R[X, A] <: BaseReader[X, A]] {
       override def flatMap[A, B](fa: R[X, A])(f: A => R[X, B]) = {
         BaseProvider.this.flatMap(fa)(f)
       }
-    }
+    })
 
 }
+

--- a/chaff-reader/src/main/scala/x7c1/chaff/reader/FlatMapped.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/reader/FlatMapped.scala
@@ -3,9 +3,9 @@ package x7c1.chaff.reader
 
 trait FlatMapped[X, A, B] extends BaseReader[X, B] {
 
-  def fa: Type[A]
+  def fa: This[A]
 
-  def f: A => Type[B]
+  def f: A => This[B]
 
   override def run: X => B = {
     FlatMapped extract this

--- a/chaff-reader/src/main/scala/x7c1/chaff/reader/Reader.scala
+++ b/chaff-reader/src/main/scala/x7c1/chaff/reader/Reader.scala
@@ -3,7 +3,7 @@ package x7c1.chaff.reader
 
 trait Reader[X, A] extends BaseReader[X, A] {
 
-  override type Type[T] = Reader[X, T]
+  override type This[T] = Reader[X, T]
 
   override def underlying = this
 }

--- a/project/ChaffSettings.scala
+++ b/project/ChaffSettings.scala
@@ -1,7 +1,7 @@
 import bintray.BintrayKeys.bintrayRepository
-
 import sbt.Def.SettingList
 import sbt.Keys._
+import sbt._
 
 
 object ChaffSettings {
@@ -17,9 +17,16 @@ object ChaffSettings {
   ))
 
   lazy val forPlugin = new SettingList(common ++
+    forKindProjector ++
     Seq(
       sbtPlugin := true,
       bintrayRepository := "sbt-plugins"
     )
   )
+
+  lazy val forKindProjector = Seq(
+    resolvers += Resolver.sonatypeRepo("releases"),
+    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
+  )
+
 }


### PR DESCRIPTION
* make chaff-process dependent on BaseReader, not on Reader
* add tests around chaff-process
* remove needless LogMessage.Multiple class
* add MonadInducible
  * to create type-class instance by multiple primitives
    * such as (pure, flatMap), (map, flatMap), etc ...
* introduce kind-projector

bugfix
* ProcessRunner#lines no longer throws Exception
